### PR TITLE
simplest log watcher ever

### DIFF
--- a/lib/LogWatcher.js
+++ b/lib/LogWatcher.js
@@ -1,0 +1,51 @@
+var util = require('util');
+var EventEmitter = require('events').EventEmitter;
+var path = require('path');
+var child_process = require('child_process');
+
+
+
+/**
+ * A LogWatcher object watches for changes mage to a log files
+ * (typically, lines are being appended). It emits a 'line' events
+ * when it detects that a new line has been added to the log file
+ *
+ * under the hood it uses a child process `tail -f` for simplicity
+ *
+ * @constructor
+ * @param filename the path to the file to watch. absolute or relative
+ */
+function LogWatcher (filename) {
+	EventEmitter.apply(this);
+	// get the absolute path 
+	this.filename = path.resolve(process.cwd(), filename);
+	// run the subprocess
+	// what we want is to get the streamed output out of
+	// tail -f <filename>
+	this.tail = child_process.spawn('tail', ['-f', this.filename]);
+	this.tail.stdout.setEncoding('utf8');
+	var lines = require('lines');
+	lines(this.tail.stdout); // tiny utility I made to stream lines
+	
+	// attach listener on new lines
+	var log_watcher = this;
+	this.tail.stdout.on('line', function(line) {
+		log_watcher.emit('line', line);
+	});
+	this.tail.once('exit', function(code, signal) {
+		if(this.killing) return;
+		log_watcher.emit('error', new Error("tail subprocess ended badly"));
+		log_watcher.emit('end');
+	});
+}
+util.inherits(LogWatcher, EventEmitter);
+
+LogWatcher.prototype.close = function close() {
+    // kill the subprocess
+	this.killing = true;
+	this.tail.kill();
+	// emit 'end' event
+	this.emit('end');
+};
+
+module.exports = LogWatcher;

--- a/test/LogWatcher-apache2.js
+++ b/test/LogWatcher-apache2.js
@@ -1,0 +1,11 @@
+var LogWatcher = require('../lib/LogWatcher');
+
+var lw = new LogWatcher('/var/log/apache2/access.log');
+lw.on('line', function(line) {
+	console.log('got a line from file %s', this.filename);
+});
+
+setTimeout(function() {
+	console.log('closing')
+	lw.close();
+}, 30000);


### PR DESCRIPTION
Hey I wrote this. It just uses the output from tail -f <filename> which does remarkably well its job so why rewrite it ? =)

there's a test in /test/ and check that it works for you as well (it watches /var/log/apache2/access.log by default, maybe yours is in another location)

You'll need to install `lines` which is tiny module that I wrote and I find it very useful.
